### PR TITLE
Add options struct and allow specification of request method

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,10 @@ func BuildClientSchemaWithOptions(ctx context.Context, options BuildClientSchema
 		return "", fmt.Errorf("failed to create query request: %w", err)
 	}
 
+	// If no headers are provided, create an empty header map, so we can add the content type header
+	if options.Headers == nil {
+		options.Headers = make(http.Header)
+	}
 	req.Header = http.Header(options.Headers)
 	req.Header.Add("Content-Type", "application/json")
 

--- a/main.go
+++ b/main.go
@@ -19,10 +19,14 @@ import (
 var introspectSchema string
 
 func BuildClientSchema(ctx context.Context, endpoint string, withoutBuiltins bool) (string, error) {
-	return BuildClientSchemaWithHeaders(ctx, endpoint, make(http.Header), withoutBuiltins)
+	return BuildClientSchemaWithMethodAndHeaders(ctx, endpoint, http.MethodPost, make(http.Header), withoutBuiltins)
 }
 
 func BuildClientSchemaWithHeaders(ctx context.Context, endpoint string, headers http.Header, withoutBuiltins bool) (string, error) {
+	return BuildClientSchemaWithMethodAndHeaders(ctx, endpoint, http.MethodPost, headers, withoutBuiltins)
+}
+
+func BuildClientSchemaWithMethodAndHeaders(ctx context.Context, endpoint string, method string, headers http.Header, withoutBuiltins bool) (string, error) {
 	buffer := new(bytes.Buffer)
 	if err := json.NewEncoder(buffer).Encode(struct {
 		Query string `json:"query"`
@@ -30,7 +34,7 @@ func BuildClientSchemaWithHeaders(ctx context.Context, endpoint string, headers 
 		return "", fmt.Errorf("failed to prepare introspection query request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buffer)
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, buffer)
 	if err != nil {
 		return "", fmt.Errorf("failed to create query request: %w", err)
 	}


### PR DESCRIPTION
The goal of this PR is to make the configuration of the application easier by not providing everything as a method parameter. Therefore, a new method was added that takes an options struct as a parameter which can be used to specify configuration options in a more readable way than as a method parameter. Existing methods now call this function to maintain backwards compatibility.

Additionally, the new configuration "method" was added to allow the specification of the request method that should be used to build the schema.