### PR TITLE
Fixed #11: fixed comments with quotes by adding new lines

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,7 +211,11 @@ func printTypes(sb *strings.Builder, types []introspectionTypeDefinition, withou
 
 func printDescription(sb *strings.Builder, description string) {
 	if description != "" {
-		sb.WriteString(fmt.Sprintf(`"""%s"""`, description))
+		sb.WriteString(`"""`)
+		sb.WriteString("\n")
+		sb.WriteString(description)
+		sb.WriteString("\n")
+		sb.WriteString(`"""`)
 		sb.WriteString("\n")
 	}
 }


### PR DESCRIPTION
Fixes #11

Added new lines between `"""` and the contents of comments to prevent quotes `"` inside comments from escaping