### PR TITLE
Add a way to generate the sdl from a json introspection file

### DIFF
--- a/gqlconvert/main.go
+++ b/gqlconvert/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/suessflorian/gqlfetch"
+)
+
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	var filePath string
+	var withoutBuiltins bool
+
+	flag.BoolVar(&withoutBuiltins, "without-builtins", false, "Do not include builtin types")
+	flag.StringVar(&filePath, "file", "schema.json", "Path to introspection file as json")
+	flag.Parse()
+
+	schema, err := gqlfetch.BuildClientSchemaFromFile(ctx, filePath, withoutBuiltins)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(schema)
+}


### PR DESCRIPTION
A propose adding a new commandline that enables generating the SDL from a local JSON file (instead of fetch over https).

In my case, it's easier to download the file locally, because I don't have easy access to the introspection endpoint from the dev environment.